### PR TITLE
availability_zone in spot fleet launch_configuration is optional

### DIFF
--- a/builtin/providers/aws/resource_aws_spot_fleet_request.go
+++ b/builtin/providers/aws/resource_aws_spot_fleet_request.go
@@ -217,7 +217,7 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 						},
 						"availability_zone": &schema.Schema{
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
 							ForceNew: true,
 						},
 					},


### PR DESCRIPTION
According to http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-fleet-examples.html, availability_zone in launch_configuration is not required. I hope this change is enough to make it so.
